### PR TITLE
Use nav instead of pages in mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name:        'tablefill'
 site_description: 'Atimated system for LaTeX and LyX table updating'
 
-pages:
+nav:
     - Home: index.md
     - Getting Started:    getting-started.md
     - Sample Workflow:    sample-workflow.md


### PR DESCRIPTION
Pages is being deprecated as of 1.0:
WARNING -  Config value: 'pages'. Warning: The 'pages' configuration 
option has been deprecated and will be removed in a future release of 
MkDocs. Use 'nav' instead.