### PR TITLE
Add mathjax config

### DIFF
--- a/docs/helpers.js
+++ b/docs/helpers.js
@@ -1,0 +1,15 @@
+window.MathJax = {
+    tex2jax: {
+        inlineMath: [ ['$','$'] ],
+        displayMath: [ ['$$','$$'] ],
+        processEscapes: true,
+    },
+    TeX: {
+        TagSide: "right",
+        TagIndent: ".8em",
+        MultLineWidth: "85%",
+        equationNumbers: {
+            autoNumber: "AMS",
+        }
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,8 +24,8 @@ theme:
         code: 'Inconsolata'
 
 extra_javascript:
-    - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.0/MathJax.js?config=TeX-AMS-MML_HTMLorMML
     - helpers.js
+    - https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.4/MathJax.js?config=TeX-AMS-MML_HTMLorMML
 
 markdown_extensions:
     - meta


### PR DESCRIPTION
In case you want to use Mathjax / use it for a later documentation project with mkdocs...

The configuration file must come _first_ in the `extra_javascript` field in `mkdocs.yml`. 

Then
```
$x=y$

$$
\begin{equation}
x^2 + y^2 = z^2
\end{equation}
$$
```
looks like:
![image](https://user-images.githubusercontent.com/15164633/53502827-d7a85600-3a7c-11e9-9a3e-b2117120750a.png)
