### PR TITLE
Turn off guess_lang

### DIFF
--- a/docs/usage/05advanced-options.md
+++ b/docs/usage/05advanced-options.md
@@ -9,7 +9,7 @@ Advanced Options
 Command-line use
 ----------------
 
-```c
+```
 tablefill [-h] [-v] [FLAGS] [-i [INPUT [INPUT ...]]] [-o OUTPUT]
           [--pvals [PVALS [PVALS ...]]] [--stars [STARS [STARS ...]]]
           [--xml-tables [INPUT [INPUT ...]]] [-t {auto,lyx,tex}]
@@ -71,7 +71,7 @@ exit, exit_msg = tablefill(template,     # required
 
 ### Required Input
 
-```c
+```
 template : str
     Name of user-written document to use as basis for update
 
@@ -84,7 +84,7 @@ output : str
 
 ### Optional Input
 
-```c
+```
 verbose : bool
     print a lot of info
 

--- a/docs/usage/06xml-engine.md
+++ b/docs/usage/06xml-engine.md
@@ -35,7 +35,7 @@ lists: See [here](http://stackoverflow.com/questions/509211#509295).
 Note that python uses 0-based indexing and that the combine engine uses
 the raw matrices (i.e. before missing entries are stripped). Each matrix
 is parsed as a list of lists, so
-```html
+```
 1  2  3        [[1,  2,  3],
 . -1 -2   -->   [., -1, -2],
 .  0  .         [.,  0,  .]]
@@ -50,4 +50,3 @@ is parsed as a list of lists, so
 It is also possible to specify tables in a separate `.xml` file and
 pass it to tablefill (there should be no leading `%` in this case) via
 `--xml-tables` in the command line or `xml_tables` in a function call.
-

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,9 +33,9 @@ markdown_extensions:
     - tables
     - fenced_code
     - admonition
-    - codehilite
+    - codehilite:
+        guess_lang: false
 
-# guess_lang:     False
 # use_pygments:   True
 # noclasses:      True
 # pygments_style: monokai


### PR DESCRIPTION
So that monospace blocks that aren't code don't get highlighted:

with `guess_lang` on:
![image](https://user-images.githubusercontent.com/15164633/53503541-433ef300-3a7e-11e9-83aa-ab632bce458c.png)

off:
![image](https://user-images.githubusercontent.com/15164633/53503571-4c2fc480-3a7e-11e9-8880-a8b67581da79.png)
