### PR TITLE
Add link to Github repository

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,12 @@
 site_name:        'tablefill'
 site_description: 'Atimated system for LaTeX and LyX table updating'
 
+# Repository
+repo_name: 'mcaceresb/tablefill'
+repo_url: 'https://github.com/mcaceresb/tablefill'
+edit_uri: 'blob/master/docs/'
+site_url: 'https://mcaceresb.github.io/tablefill/'
+
 nav:
     - Home: index.md
     - Getting Started:    getting-started.md


### PR DESCRIPTION
Adds Github link in top right of every page. Also adds the "edit" button to each page. Since `edit_uri` is set to `'blob/master/docs/'`, clicking on it gets to the Github viewing page. This means that non signed in users don't have to sign in to reach the github content. Then they can click the edit button on Github to change information.


![image](https://user-images.githubusercontent.com/15164633/53528206-e7449080-3ab6-11e9-8e7e-0e43ba7a6837.png)
